### PR TITLE
Fixed path to Library module, ts-node changed to devDependency

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,4 @@
-import { doHighlight, deserializeHighlights, serializeHighlights, removeHighlights, createWrapper, highlightRange } from "../src/Library";
+import { doHighlight, deserializeHighlights, serializeHighlights, removeHighlights, createWrapper, highlightRange } from "./Library";
 import { TextHighlighter } from "./TextHighlighter";
 import { optionsImpl } from "./types";
 export { doHighlight, deserializeHighlights, serializeHighlights, removeHighlights, optionsImpl, createWrapper, highlightRange, TextHighlighter };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.TextHighlighter = exports.highlightRange = exports.createWrapper = exports.optionsImpl = exports.removeHighlights = exports.serializeHighlights = exports.deserializeHighlights = exports.doHighlight = void 0;
-var Library_1 = require("../src/Library");
+var Library_1 = require("./Library");
 Object.defineProperty(exports, "doHighlight", { enumerable: true, get: function () { return Library_1.doHighlight; } });
 Object.defineProperty(exports, "deserializeHighlights", { enumerable: true, get: function () { return Library_1.deserializeHighlights; } });
 Object.defineProperty(exports, "serializeHighlights", { enumerable: true, get: function () { return Library_1.serializeHighlights; } });

--- a/package.json
+++ b/package.json
@@ -57,9 +57,7 @@
     "ts-jest": "^26.1.1",
     "ts-loader": "^8.0.9",
     "tsify": "^5.0.2",
-    "typescript": "^4.0.5"
-  },
-  "dependencies": {
+    "typescript": "^4.0.5",
     "ts-node": "^10.1.0"
   },
   "directories": {


### PR DESCRIPTION
Once added using Yarn to a node-based project, the compilation step were crashing due to an error in path.